### PR TITLE
書籍の評価を並列化して取得するようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem "nokogiri"
 gem "font-awesome-rails"
 
 gem "render_async"
+
+gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,7 @@ DEPENDENCIES
   listen (~> 3.2)
   nokogiri
   open_bd
+  parallel
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)

--- a/app/models/bookmeter.rb
+++ b/app/models/bookmeter.rb
@@ -3,23 +3,20 @@
 require "open-uri"
 
 class Bookmeter
+  attr_reader :average_rating, :review_count, :url
+
   def initialize(isbn)
     @isbn = isbn
   end
 
-  def average_rating
-    if doc.at_css(".supplement__value.average").nil?
-      "評価なし"
-    else
-      (doc.at_css(".supplement__value.average").text.to_i * 0.05).round(2)
-    end
-  end
+  def fetch
+    @book = parse_book_path
 
-  def review_count
-    if doc.at_css(".supplement__value.count").nil?
-      "0"
-    else
-      doc.at_css(".supplement__value.count").text
+    if book_exists?
+      @url = parse_url
+      @doc = Nokogiri::HTML.parse(URI.open(@url))
+      @average_rating = parse_average_rating
+      @review_count = parse_review_count
     end
   end
 
@@ -27,19 +24,15 @@ class Bookmeter
     "読書メーター"
   end
 
-  def url
-    "https://bookmeter.com#{parse_book_path}"
-  end
-
-  def book
-    parse_book_path
+  def book_exists?
+    if @book.nil?
+      false
+    else
+      true
+    end
   end
 
   private
-    def doc
-      Nokogiri::HTML.parse(URI.open(url))
-    end
-
     def search_url
       "https://bookmeter.com/search?keyword=#{@isbn}"
     end
@@ -52,6 +45,26 @@ class Bookmeter
         nil
       else
         hash["resources"][0]["contents"]["book"]["path"]
+      end
+    end
+
+    def parse_url
+      "https://bookmeter.com#{parse_book_path}"
+    end
+
+    def parse_average_rating
+      if @doc.at_css(".supplement__value.average").nil?
+        "評価なし"
+      else
+        (@doc.at_css(".supplement__value.average").text.to_i * 0.05).round(2)
+      end
+    end
+
+    def parse_review_count
+      if @doc.at_css(".supplement__value.count").nil?
+        "0"
+      else
+        @doc.at_css(".supplement__value.count").text
       end
     end
 end

--- a/app/models/hongasuki.rb
+++ b/app/models/hongasuki.rb
@@ -3,39 +3,36 @@
 require "open-uri"
 
 class Hongasuki
+  attr_reader :average_rating, :review_count, :url
+
   def initialize(isbn)
     @isbn = isbn
   end
 
-  def average_rating
-    if doc.at_css("b[itemprop='average']").text == "0"
-      "評価なし"
-    else
-      doc.at_css("b[itemprop='average']").text
-    end
-  end
+  def fetch
+    @book = parse_book_path
 
-  def review_count
-    doc.at_css("b[itemprop='votes']").text
+    if book_exists?
+      @url = parse_url
+      @doc = Nokogiri::HTML.parse(URI.open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE))
+      @average_rating = parse_average_rating
+      @review_count = parse_review_count
+    end
   end
 
   def name
     "本が好き！"
   end
 
-  def url
-    "https://www.honzuki.jp#{parse_book_path}"
-  end
-
-  def book
-    parse_book_path
+  def book_exists?
+    if @book.nil?
+      false
+    else
+      true
+    end
   end
 
   private
-    def doc
-      Nokogiri::HTML.parse(URI.open(url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE))
-    end
-
     def search_url
       "https://www.honzuki.jp/book/book_search/index.html?search_in=honzuki&isbn=#{@isbn}"
     end
@@ -47,5 +44,21 @@ class Hongasuki
       else
         doc.at_css("td > a").attributes["href"].value
       end
+    end
+
+    def parse_average_rating
+      if @doc.at_css("b[itemprop='average']").text == "0"
+        "評価なし"
+      else
+        @doc.at_css("b[itemprop='average']").text
+      end
+    end
+
+    def parse_review_count
+      @doc.at_css("b[itemprop='votes']").text
+    end
+
+    def parse_url
+      "https://www.honzuki.jp#{parse_book_path}"
     end
 end

--- a/app/models/rakuten_books.rb
+++ b/app/models/rakuten_books.rb
@@ -1,27 +1,31 @@
 # frozen_string_literal: true
 
 class RakutenBooks
+  attr_reader :average_rating, :review_count, :url
+
   def initialize(isbn)
     @isbn = isbn
   end
 
-  def average_rating
-    book.review_average
+  def fetch
+    @book = RakutenWebService::Books::Book.search(isbn: @isbn).first
+
+    if book_exists?
+      @url = @book.affiliate_url
+      @average_rating = @book.review_average
+      @review_count = @book.review_count
+    end
   end
 
-  def review_count
-    book.review_count
+  def book_exists?
+    if @book.nil?
+      false
+    else
+      true
+    end
   end
 
   def name
     "楽天ブックス"
-  end
-
-  def url
-    book.affiliate_url
-  end
-
-  def book
-    RakutenWebService::Books::Book.search(isbn: @isbn).first
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+require "parallel"
+
 class Service
   def self.search(isbn)
     services = []
 
     service_list.each do |service_name|
       services << Object.const_get(service_name).new(isbn)
+    end
+
+    Parallel.each(services, in_threads: service_list.size) do |service|
+      service.fetch
     end
 
     services

--- a/app/views/search/_book_reviews.html.slim
+++ b/app/views/search/_book_reviews.html.slim
@@ -1,6 +1,6 @@
 .book-reviews
   - @services.each do |service|
-    - if service.book.present?
+    - if service.book_exists?
       .book-reviews__book-review
         .book-reviews__star-rating
           .book-reviews__star-rating--front style="width: #{20 * service.average_rating.to_f}%"

--- a/test/models/bookmeter_test.rb
+++ b/test/models/bookmeter_test.rb
@@ -38,19 +38,15 @@ class BookmeterTest < ActiveSupport::TestCase
     assert_equal("読書メーター", @bookmeter.name)
   end
 
-  test "#book" do
-    assert @bookmeter.book
+  test "#book_exists?" do
+    @bookmeter.fetch
+    assert @bookmeter.book_exists?
   end
 
-  test "#url" do
+  test "#fetch" do
+    @bookmeter.fetch
     assert_equal("https://bookmeter.com/books/548397", @bookmeter.url)
-  end
-
-  test "#average_rating" do
     assert_equal(4.1, @bookmeter.average_rating)
-  end
-
-  test "#review_count" do
     assert_equal("1094", @bookmeter.review_count)
   end
 end

--- a/test/models/hongasuki_test.rb
+++ b/test/models/hongasuki_test.rb
@@ -38,19 +38,15 @@ class HongasukiTest < ActiveSupport::TestCase
     assert_equal("本が好き！", @hongasuki.name)
   end
 
-  test "#book" do
-    assert @hongasuki.book
+  test "#book_exists?" do
+    @hongasuki.fetch
+    assert @hongasuki.book_exists?
   end
 
-  test "#url" do
+  test "#fetch" do
+    @hongasuki.fetch
     assert_equal("https://www.honzuki.jp/book/9931/", @hongasuki.url)
-  end
-
-  test "#average_rating" do
     assert_equal("4.11", @hongasuki.average_rating)
-  end
-
-  test "#review_count" do
     assert_equal("10", @hongasuki.review_count)
   end
 end

--- a/test/models/rakuten_books_test.rb
+++ b/test/models/rakuten_books_test.rb
@@ -25,19 +25,15 @@ class RakutenBooksTest < ActiveSupport::TestCase
     assert_equal("楽天ブックス", @rakuten_books.name)
   end
 
-  test "#book" do
-    assert @rakuten_books.book
+  test "#book_exists?" do
+    @rakuten_books.fetch
+    assert @rakuten_books.book_exists?
   end
 
-  test "#average_rating" do
+  test "#fetch" do
+    @rakuten_books.fetch
     assert_equal("3.93", @rakuten_books.average_rating)
-  end
-
-  test "#review_count" do
     assert_equal(192, @rakuten_books.review_count)
-  end
-
-  test "#url" do
     assert_equal("https://hb.afl.rakuten.co.jp/hgc/g00q0727.zh7wt7c9.g00q0727.zh7wub5e/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F1656073%2F",
                  @rakuten_books.url)
   end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+
+class ServiceTest < ActiveSupport::TestCase
+  setup do
+    stub_request(:get, "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?affiliateId=#{ENV["RAKUTEN_AFFILIATE_ID"]}&applicationId=#{ENV["RAKUTEN_APP_ID"]}&formatVersion=2&isbn=9784101010014").
+      with(
+        headers: {
+          "Accept"=>"*/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      ).
+        to_return(
+          status: 200,
+          body: File.read(Rails.root.join("test/fixtures/files/rakuten_books.json")),
+          headers: { "Content-Type" =>  "application/json" }
+        )
+
+    stub_request(:get, "https://bookmeter.com/search?keyword=9784101010014").
+      with(
+        headers: {
+          "Accept"=>"*/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      ).
+        to_return(
+          status: 200,
+          body: File.read(Rails.root.join("test/fixtures/files/bookmeter.json")),
+          headers: { "Content-Type" =>  "application/json" }
+        )
+
+    stub_request(:get, "https://bookmeter.com/books/548397").
+      with(
+        headers: {
+          "Accept"=>"*/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      ).
+        to_return(
+          status: 200,
+          body: File.read(Rails.root.join("test/fixtures/files/bookmeter.html")),
+          headers: { "Content-Type" =>  "text/html" }
+        )
+
+    stub_request(:get, "https://www.honzuki.jp/book/book_search/index.html?search_in=honzuki&isbn=9784101010014").
+      with(
+        headers: {
+          "Accept"=>"*/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      ).
+        to_return(
+          status: 200,
+          body: File.read(Rails.root.join("test/fixtures/files/hongasuki_search_url.html")),
+          headers: { "Content-Type" =>  "text/html" }
+        )
+
+    stub_request(:get, "https://www.honzuki.jp/book/9931/").
+      with(
+        headers: {
+          "Accept"=>"*/*",
+          "Accept-Encoding"=>"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      ).
+        to_return(
+          status: 200,
+          body: File.read(Rails.root.join("test/fixtures/files/hongasuki.html")),
+          headers: { "Content-Type" =>  "text/html" }
+        )
+  end
+
+  test ".search" do
+    services = Service.search("9784101010014")
+
+    assert services[0].kind_of?(RakutenBooks)
+    assert services[1].kind_of?(Bookmeter)
+    assert services[2].kind_of?(Hongasuki)
+  end
+end


### PR DESCRIPTION
Ref #15 

## 概要
ISBNを入力して検索後、書籍の評価を取得して表示するまでに平均して5秒から6秒かかっていたので、その時間を短縮するために、並列化して書籍の評価を取得するようにした。並列化後は平均5秒から6秒かかっていたものが平均して1.5秒~3秒になった、たまに遅い時もある。

## 動作画面
![](http://g.recordit.co/pBhWoRihpj.gif)