### PR TITLE
fetchメソッドを修正

### DIFF
--- a/app/models/bookmeter.rb
+++ b/app/models/bookmeter.rb
@@ -10,8 +10,6 @@ class Bookmeter
   end
 
   def fetch
-    @book = parse_book_path
-
     if book_exists?
       @url = parse_url
       @doc = Nokogiri::HTML.parse(URI.open(@url))
@@ -25,7 +23,7 @@ class Bookmeter
   end
 
   def book_exists?
-    if @book.nil?
+    if parse_book_path.nil?
       false
     else
       true

--- a/app/models/hongasuki.rb
+++ b/app/models/hongasuki.rb
@@ -10,8 +10,6 @@ class Hongasuki
   end
 
   def fetch
-    @book = parse_book_path
-
     if book_exists?
       @url = parse_url
       @doc = Nokogiri::HTML.parse(URI.open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE))
@@ -25,7 +23,7 @@ class Hongasuki
   end
 
   def book_exists?
-    if @book.nil?
+    if parse_book_path.nil?
       false
     else
       true

--- a/app/models/rakuten_books.rb
+++ b/app/models/rakuten_books.rb
@@ -8,17 +8,17 @@ class RakutenBooks
   end
 
   def fetch
-    @book = RakutenWebService::Books::Book.search(isbn: @isbn).first
-
     if book_exists?
-      @url = @book.affiliate_url
-      @average_rating = @book.review_average
-      @review_count = @book.review_count
+      book = RakutenWebService::Books::Book.search(isbn: @isbn).first
+
+      @url = book.affiliate_url
+      @average_rating = book.review_average
+      @review_count = book.review_count
     end
   end
 
   def book_exists?
-    if @book.nil?
+    if RakutenWebService::Books::Book.search(isbn: @isbn).first.nil?
       false
     else
       true

--- a/test/models/bookmeter_test.rb
+++ b/test/models/bookmeter_test.rb
@@ -39,7 +39,6 @@ class BookmeterTest < ActiveSupport::TestCase
   end
 
   test "#book_exists?" do
-    @bookmeter.fetch
     assert @bookmeter.book_exists?
   end
 

--- a/test/models/hongasuki_test.rb
+++ b/test/models/hongasuki_test.rb
@@ -39,7 +39,6 @@ class HongasukiTest < ActiveSupport::TestCase
   end
 
   test "#book_exists?" do
-    @hongasuki.fetch
     assert @hongasuki.book_exists?
   end
 

--- a/test/models/rakuten_books_test.rb
+++ b/test/models/rakuten_books_test.rb
@@ -26,7 +26,6 @@ class RakutenBooksTest < ActiveSupport::TestCase
   end
 
   test "#book_exists?" do
-    @rakuten_books.fetch
     assert @rakuten_books.book_exists?
   end
 


### PR DESCRIPTION
## 修正理由
#fetchメソッドが呼ばれた後でないと#book_exists?メソッドが動くようになっていなかったため、シンプルにするために修正をした。